### PR TITLE
Feat/security hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ build/
 .cursor/
 skills-lock.json
 .augment/
+CLAUDE.md
 
 # Archivos de despliegue
 *.bak

--- a/app_checklist/settings.py
+++ b/app_checklist/settings.py
@@ -36,7 +36,27 @@ if ENVIRONMENT == 'development':
 else:
     DEBUG = False
 
-ALLOWED_HOSTS = ["*"]
+# Dev: localhost only. Prod: read from env (Railway/Render set this automatically).
+if ENVIRONMENT == 'development':
+    ALLOWED_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0']
+else:
+    ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=['chcklistapp-production.up.railway.app'])
+
+# ── Security settings ─────────────────────────────────────────────────────────
+# Applied in both environments (safe for HTTP dev server)
+SECURE_CONTENT_TYPE_NOSNIFF = True
+X_FRAME_OPTIONS = 'DENY'
+CSRF_COOKIE_HTTPONLY = True
+SESSION_COOKIE_HTTPONLY = True  # Django default, made explicit
+
+# Applied only in production (require HTTPS)
+if ENVIRONMENT == 'production':
+    SECURE_SSL_REDIRECT = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_HSTS_SECONDS = 31536000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
 
 
 # Application definition
@@ -57,6 +77,7 @@ INSTALLED_APPS = [
 # Middleware optimizado para rendimiento
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'checklist.middleware.SecurityHeadersMiddleware',  # Security headers on every response
     'whitenoise.middleware.WhiteNoiseMiddleware',  # WhiteNoise debe estar justo después de SecurityMiddleware
     'django.middleware.gzip.GZipMiddleware',  # Compresión Gzip para respuestas
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -119,6 +140,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
     {
         'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {'min_length': 10},
     },
     {
         'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
@@ -258,6 +280,12 @@ LOGGING = {
             'handlers': ['console'],
             'level': 'DEBUG',
             'propagate': True,
+        },
+        # Captures CSRF failures, SuspiciousOperation, DisallowedHost, etc.
+        'django.security': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+            'propagate': False,
         },
     },
 }

--- a/checklist/middleware.py
+++ b/checklist/middleware.py
@@ -1,9 +1,12 @@
 from django.utils.deprecation import MiddlewareMixin
+from django.conf import settings as django_settings
 import logging
 from django.core.cache import cache
 from django.utils import translation
 from django.shortcuts import redirect
 from django.urls import reverse
+
+_ALLOWED_LANGUAGES = {'es', 'en'}
 
 # Configurar logging
 logger = logging.getLogger(__name__)
@@ -66,8 +69,10 @@ class CachedLanguageMiddleware(MiddlewareMixin):
         
         # Verificar si hay un cambio explícito de idioma
         if 'set_language' in request.GET or 'language' in request.POST:
-            # Procesar el cambio de idioma
+            # Procesar el cambio de idioma — validate against allowed values
             language = request.POST.get('language', request.GET.get('set_language', 'es'))
+            if language not in _ALLOWED_LANGUAGES:
+                language = 'es'
             request.session['language'] = language
             # Guardar en caché
             cache.set(cache_key, language, 60 * 60 * 24)  # 24 horas
@@ -100,4 +105,37 @@ class CachedLanguageMiddleware(MiddlewareMixin):
         """
         if hasattr(response, 'context_data') and response.context_data is not None:
             response.context_data['LANGUAGE_CODE'] = request.LANGUAGE_CODE
+        return response
+
+
+class SecurityHeadersMiddleware:
+    """
+    Adds HTTP security headers to every response.
+    CSP allows 'unsafe-inline' because crispy-forms and Bootstrap emit inline styles/scripts.
+    Tighten CSP further once inline usage is eliminated.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # In production Supabase CDN serves avatars, so we allow https: for img-src.
+        if django_settings.ENVIRONMENT == 'production':
+            img_src = "'self' data: https:"
+        else:
+            img_src = "'self' data:"
+
+        self._csp = (
+            "default-src 'self'; "
+            "script-src 'self' 'unsafe-inline'; "
+            "style-src 'self' 'unsafe-inline'; "
+            f"img-src {img_src}; "
+            "font-src 'self'; "
+            "connect-src 'self';"
+        )
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response['X-Content-Type-Options'] = 'nosniff'
+        response['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+        response['Permissions-Policy'] = 'geolocation=(), camera=(), microphone=()'
+        response['Content-Security-Policy'] = self._csp
         return response

--- a/checklist/middleware.py
+++ b/checklist/middleware.py
@@ -125,10 +125,10 @@ class SecurityHeadersMiddleware:
 
         self._csp = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline'; "
-            "style-src 'self' 'unsafe-inline'; "
+            "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
             f"img-src {img_src}; "
-            "font-src 'self'; "
+            "font-src 'self' https://cdn.jsdelivr.net; "
             "connect-src 'self';"
         )
 

--- a/checklist/models.py
+++ b/checklist/models.py
@@ -4,9 +4,25 @@ from django.utils.timezone import now
 from django.utils import timezone
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django.core.exceptions import ValidationError
+import os
 import uuid
 import hashlib
 from datetime import datetime, timedelta
+
+_ALLOWED_IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.gif', '.webp'}
+_MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
+
+
+def validate_image_extension(file):
+    ext = os.path.splitext(file.name)[1].lower()
+    if ext not in _ALLOWED_IMAGE_EXTENSIONS:
+        raise ValidationError(f"Only {', '.join(_ALLOWED_IMAGE_EXTENSIONS)} images are allowed.")
+
+
+def validate_image_size(file):
+    if file.size > _MAX_IMAGE_SIZE_BYTES:
+        raise ValidationError("Image must be under 5 MB.")
 
 # Models todo_list
 class TodoList(models.Model):
@@ -76,7 +92,7 @@ class BankQuestion(models.Model):
   max_label = models.CharField(max_length=50, blank=True, null=True)
   
   # Imagen para la pregunta (opcional)
-  image = models.ImageField(upload_to='bank_question_images/', blank=True, null=True)
+  image = models.ImageField(upload_to='bank_question_images/', blank=True, null=True, validators=[validate_image_extension, validate_image_size])
   
   # Campo para controlar si se permiten adjuntos
   allow_attachments = models.BooleanField(default=False, help_text="Allow users to attach files or URLs to this question")
@@ -277,7 +293,7 @@ class GQuestion(models.Model):
   max_label = models.CharField(max_length=50, blank=True, null=True)
   
   # Imagen para la pregunta (opcional)
-  image = models.ImageField(upload_to='gform_question_images/', blank=True, null=True)
+  image = models.ImageField(upload_to='gform_question_images/', blank=True, null=True, validators=[validate_image_extension, validate_image_size])
   
   # Campo para controlar si se permiten adjuntos
   allow_attachments = models.BooleanField(default=False, help_text="Allow users to attach files or URLs to this question")
@@ -328,7 +344,7 @@ class GAnswer(models.Model):
   text_answer = models.TextField(blank=True, null=True)
   
   # Campos para archivos adjuntos en respuestas
-  image = models.ImageField(upload_to='gform_answer_images/', blank=True, null=True)
+  image = models.ImageField(upload_to='gform_answer_images/', blank=True, null=True, validators=[validate_image_extension, validate_image_size])
   video = models.FileField(upload_to='gform_answer_videos/', blank=True, null=True)
   file_url = models.URLField(blank=True, null=True)
   

--- a/checklist/models.py
+++ b/checklist/models.py
@@ -11,7 +11,9 @@ import hashlib
 from datetime import datetime, timedelta
 
 _ALLOWED_IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.gif', '.webp'}
-_MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
+_ALLOWED_VIDEO_EXTENSIONS = {'.mp4', '.webm', '.ogg', '.mov'}
+_MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024    # 5 MB
+_MAX_VIDEO_SIZE_BYTES = 50 * 1024 * 1024   # 50 MB
 
 
 def validate_image_extension(file):
@@ -23,6 +25,17 @@ def validate_image_extension(file):
 def validate_image_size(file):
     if file.size > _MAX_IMAGE_SIZE_BYTES:
         raise ValidationError("Image must be under 5 MB.")
+
+
+def validate_video_extension(file):
+    ext = os.path.splitext(file.name)[1].lower()
+    if ext not in _ALLOWED_VIDEO_EXTENSIONS:
+        raise ValidationError(f"Only {', '.join(_ALLOWED_VIDEO_EXTENSIONS)} videos are allowed.")
+
+
+def validate_video_size(file):
+    if file.size > _MAX_VIDEO_SIZE_BYTES:
+        raise ValidationError("Video must be under 50 MB.")
 
 # Models todo_list
 class TodoList(models.Model):
@@ -345,7 +358,7 @@ class GAnswer(models.Model):
   
   # Campos para archivos adjuntos en respuestas
   image = models.ImageField(upload_to='gform_answer_images/', blank=True, null=True, validators=[validate_image_extension, validate_image_size])
-  video = models.FileField(upload_to='gform_answer_videos/', blank=True, null=True)
+  video = models.FileField(upload_to='gform_answer_videos/', blank=True, null=True, validators=[validate_video_extension, validate_video_size])
   file_url = models.URLField(blank=True, null=True)
   
   def __str__(self):

--- a/checklist/static/js/demo-hero.js
+++ b/checklist/static/js/demo-hero.js
@@ -7,7 +7,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // Detectar si estamos en un dispositivo táctil de manera más confiable
   const isTouchDevice = "ontouchstart" in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0
 
-  console.log("¿Es dispositivo táctil?", isTouchDevice)
+  window.APP_DEBUG && console.log("¿Es dispositivo táctil?", isTouchDevice)
 
   // Variables para el arrastre
   let draggedCard = null
@@ -119,7 +119,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // Iniciar un temporizador para detectar pulsación larga
     clearTimeout(longPressTimer) // Limpiar cualquier temporizador existente
     longPressTimer = setTimeout(() => {
-      console.log("Iniciando arrastre táctil")
+      window.APP_DEBUG && console.log("Iniciando arrastre táctil")
       startDrag(this, touch.clientX, touch.clientY)
     }, 500) // 500ms para pulsación larga
 

--- a/checklist/static/js/edit_form.js
+++ b/checklist/static/js/edit_form.js
@@ -1,3 +1,10 @@
+// Escape HTML to prevent XSS when injecting user-controlled strings via innerHTML
+function esc(s) {
+  const d = document.createElement("div")
+  d.textContent = String(s ?? "")
+  return d.innerHTML
+}
+
 document.addEventListener('DOMContentLoaded', function() {
   // Mostrar/ocultar campos específicos según el tipo de pregunta
   const questionType = document.getElementById('id_question_type');
@@ -630,22 +637,23 @@ document.addEventListener('DOMContentLoaded', function() {
           questionItem.dataset.type = question.question_type;
           questionItem.draggable = true;
           
+          const qid = esc(question.id);
           questionItem.innerHTML = `
-            <span class="bank-question-type">${question.question_type_display}</span>
-            <div class="bank-question-text">${question.text}</div>
+            <span class="bank-question-type">${esc(question.question_type_display)}</span>
+            <div class="bank-question-text">${esc(question.text)}</div>
             <div class="bank-question-meta">
               <div class="bank-question-usage">
-                <i class="bi bi-bar-chart"></i> Usado ${question.usage_count} veces
+                <i class="bi bi-bar-chart"></i> Usado ${esc(question.usage_count)} veces
               </div>
             </div>
             <div class="bank-question-actions">
-              <button type="button" class="bank-action-btn add-btn add-bank-question-btn" data-id="${question.id}" title="Añadir al formulario">
+              <button type="button" class="bank-action-btn add-btn add-bank-question-btn" data-id="${qid}" title="Añadir al formulario">
                 <i class="bi bi-plus"></i>
               </button>
-              <button type="button" class="bank-action-btn edit-btn edit-bank-question-btn" data-id="${question.id}" title="Editar pregunta">
+              <button type="button" class="bank-action-btn edit-btn edit-bank-question-btn" data-id="${qid}" title="Editar pregunta">
                 <i class="bi bi-pencil"></i>
               </button>
-              <button type="button" class="bank-action-btn delete-btn delete-bank-question-btn" data-id="${question.id}" title="Eliminar pregunta">
+              <button type="button" class="bank-action-btn delete-btn delete-bank-question-btn" data-id="${qid}" title="Eliminar pregunta">
                 <i class="bi bi-trash"></i>
               </button>
             </div>

--- a/checklist/static/js/edit_form.js
+++ b/checklist/static/js/edit_form.js
@@ -376,7 +376,7 @@ document.addEventListener('DOMContentLoaded', function() {
     .then(response => response.json())
     .then(data => {
       if (data.success) {
-        console.log('Orden de preguntas actualizado');
+        window.APP_DEBUG && console.log('Orden de preguntas actualizado');
       } else {
         console.error('Error al actualizar el orden de preguntas:', data.error);
       }
@@ -401,7 +401,7 @@ document.addEventListener('DOMContentLoaded', function() {
     .then(response => response.json())
     .then(data => {
       if (data.success) {
-        console.log('Orden de opciones actualizado');
+        window.APP_DEBUG && console.log('Orden de opciones actualizado');
       } else {
         console.error('Error al actualizar el orden de opciones:', data.error);
       }

--- a/checklist/static/js/question_bank.js
+++ b/checklist/static/js/question_bank.js
@@ -79,7 +79,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Modificar la función initBankQuestionButtons para asegurar que los event listeners se añadan correctamente
   function initBankQuestionButtons() {
-    console.log("Inicializando botones del banco de preguntas...")
+    window.APP_DEBUG && console.log("Inicializando botones del banco de preguntas...")
 
     // Botones para eliminar preguntas del banco
     document.querySelectorAll(".delete-bank-question-btn").forEach((btn) => {
@@ -93,7 +93,7 @@ document.addEventListener("DOMContentLoaded", () => {
       newBtn.addEventListener("click", function (e) {
         e.preventDefault()
         e.stopPropagation()
-        console.log("Botón eliminar clickeado para ID:", this.dataset.id)
+        window.APP_DEBUG && console.log("Botón eliminar clickeado para ID:", this.dataset.id)
 
         const questionId = this.dataset.id
 
@@ -147,7 +147,7 @@ document.addEventListener("DOMContentLoaded", () => {
       newBtn.addEventListener("click", function (e) {
         e.preventDefault()
         e.stopPropagation()
-        console.log("Botón añadir clickeado para ID:", this.dataset.id)
+        window.APP_DEBUG && console.log("Botón añadir clickeado para ID:", this.dataset.id)
 
         const questionId = this.dataset.id
         // Obtener el ID del formulario de la URL
@@ -170,14 +170,14 @@ document.addEventListener("DOMContentLoaded", () => {
       newBtn.addEventListener("click", function (e) {
         e.preventDefault()
         e.stopPropagation()
-        console.log("Botón editar clickeado para ID:", this.dataset.id)
+        window.APP_DEBUG && console.log("Botón editar clickeado para ID:", this.dataset.id)
 
         const questionId = this.dataset.id
         editBankQuestion(questionId)
       })
     })
 
-    console.log("Botones del banco de preguntas inicializados correctamente")
+    window.APP_DEBUG && console.log("Botones del banco de preguntas inicializados correctamente")
   }
 
   // Función para inicializar Sortable (drag and drop)
@@ -230,7 +230,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Función para añadir una pregunta desde el banco
   function addQuestionFromBank(formId, questionId) {
-    console.log(`Añadiendo pregunta ${questionId} al formulario ${formId}`)
+    window.APP_DEBUG && console.log(`Añadiendo pregunta ${questionId} al formulario ${formId}`)
 
     // Crear un token CSRF
     const csrftoken = getCookie("csrftoken")
@@ -285,7 +285,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Función para editar una pregunta del banco
   function editBankQuestion(questionId) {
-    console.log("Editando pregunta del banco con ID:", questionId)
+    window.APP_DEBUG && console.log("Editando pregunta del banco con ID:", questionId)
 
     // Obtener los datos de la pregunta
     fetch(`/forms/question-bank/${questionId}/`, {
@@ -428,7 +428,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Función para eliminar una pregunta del banco
   function deleteBankQuestion(questionId) {
-    console.log("Ejecutando deleteBankQuestion para ID:", questionId)
+    window.APP_DEBUG && console.log("Ejecutando deleteBankQuestion para ID:", questionId)
 
     // Crear un token CSRF
     const csrftoken = getCookie("csrftoken")
@@ -721,7 +721,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
             // Verificar si esta pregunta ya ha sido añadida por ID o contenido
             if (addedIds.has(question.id) || addedContent.has(contentKey)) {
-              console.log(`Pregunta duplicada detectada en el frontend: ${question.id} - ${contentKey}`)
+              window.APP_DEBUG && console.log(`Pregunta duplicada detectada en el frontend: ${question.id} - ${contentKey}`)
               return // Saltar esta pregunta
             }
 
@@ -769,7 +769,7 @@ document.addEventListener("DOMContentLoaded", () => {
             initSortable()
           }
 
-          console.log(`Banco de preguntas actualizado: ${addedIds.size} preguntas únicas cargadas`)
+          window.APP_DEBUG && console.log(`Banco de preguntas actualizado: ${addedIds.size} preguntas únicas cargadas`)
 
           // Ejecutar limpieza de duplicados en el DOM después de cargar
           setTimeout(removeDuplicatesFromDOM, 100)
@@ -821,13 +821,13 @@ document.addEventListener("DOMContentLoaded", () => {
       if (ids.has(id)) {
         // Este es un duplicado por ID
         duplicates.push(item)
-        console.log(`Duplicado por ID: ${id}`)
+        window.APP_DEBUG && console.log(`Duplicado por ID: ${id}`)
       }
       // Verificar duplicados por contenido
       else if (text && textMap.has(contentKey)) {
         // Este es un duplicado por contenido
         duplicates.push(item)
-        console.log(`Duplicado por contenido: ${contentKey}`)
+        window.APP_DEBUG && console.log(`Duplicado por contenido: ${contentKey}`)
       } else {
         // Este es el primer elemento con este ID y contenido
         ids.set(id, item)
@@ -843,7 +843,7 @@ document.addEventListener("DOMContentLoaded", () => {
     })
 
     if (duplicates.length > 0) {
-      console.log(`Eliminados ${duplicates.length} elementos duplicados del DOM`)
+      window.APP_DEBUG && console.log(`Eliminados ${duplicates.length} elementos duplicados del DOM`)
     }
 
     return duplicates.length
@@ -870,7 +870,7 @@ document.addEventListener("DOMContentLoaded", () => {
           }
 
           if (data.duplicates_removed > 0) {
-            console.log(
+            window.APP_DEBUG && console.log(
               `Limpieza en servidor: ${data.duplicates_removed} eliminados, ${data.questions_kept} mantenidos`,
             )
             // Actualizar el banco de preguntas solo si se eliminaron duplicados
@@ -1068,7 +1068,7 @@ document.addEventListener("DOMContentLoaded", () => {
     })
 
     if (duplicatesFound.length > 0) {
-      console.log(`Se encontraron ${duplicatesFound.length} duplicados en el DOM`)
+      window.APP_DEBUG && console.log(`Se encontraron ${duplicatesFound.length} duplicados en el DOM`)
       // Limpiar duplicados automáticamente
       removeDuplicatesFromDOM()
     }
@@ -1090,7 +1090,7 @@ document.addEventListener("DOMContentLoaded", () => {
       // Solo actualizar si el banco está visible
       const questionBank = document.getElementById("questionBank")
       if (questionBank && questionBank.offsetParent !== null) {
-        console.log("Actualizando banco de preguntas automáticamente...")
+        window.APP_DEBUG && console.log("Actualizando banco de preguntas automáticamente...")
         updateQuestionBank()
 
         // Limpiar duplicados en el servidor cada 30 segundos
@@ -1234,7 +1234,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 // Asegurarse de que la función se ejecute cuando el DOM esté completamente cargado
 document.addEventListener("DOMContentLoaded", () => {
-  console.log("DOM cargado, inicializando botones del banco...")
+  window.APP_DEBUG && console.log("DOM cargado, inicializando botones del banco...")
   initBankQuestionButtons()
 
   // También inicializar después de actualizar el banco de preguntas

--- a/checklist/static/js/question_bank.js
+++ b/checklist/static/js/question_bank.js
@@ -2,6 +2,13 @@
 let bootstrap
 let Sortable
 
+// Escape HTML to prevent XSS when injecting user-controlled strings via innerHTML
+function esc(s) {
+  const d = document.createElement("div")
+  d.textContent = String(s ?? "")
+  return d.innerHTML
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   // Asignar las variables globales si están disponibles
   bootstrap = window.bootstrap || {}
@@ -734,25 +741,24 @@ document.addEventListener("DOMContentLoaded", () => {
             questionItem.dataset.id = question.id
             questionItem.dataset.type = question.question_type
             questionItem.dataset.text = question.text.toLowerCase().replace(/\s+/g, "-") // Para comparación de duplicados
-            questionItem.dataset.hash = question.hash || "" // Para comparación de duplicados
             questionItem.draggable = true
 
             questionItem.innerHTML = `
-              <span class="bank-question-type">${question.question_type_display}</span>
-              <div class="bank-question-text">${question.text}</div>
+              <span class="bank-question-type">${esc(question.question_type_display)}</span>
+              <div class="bank-question-text">${esc(question.text)}</div>
               <div class="bank-question-meta">
                 <div class="bank-question-usage">
-                  <i class="bi bi-bar-chart"></i> Usado ${question.usage_count} veces
+                  <i class="bi bi-bar-chart"></i> Usado ${esc(question.usage_count)} veces
                 </div>
               </div>
               <div class="bank-question-actions">
-                <button type="button" class="bank-action-btn add-btn add-bank-question-btn" data-id="${question.id}" title="Añadir al formulario">
+                <button type="button" class="bank-action-btn add-btn add-bank-question-btn" data-id="${esc(question.id)}" title="Añadir al formulario">
                   <i class="bi bi-plus"></i>
                 </button>
-                <button type="button" class="bank-action-btn edit-btn edit-bank-question-btn" data-id="${question.id}" title="Editar pregunta">
+                <button type="button" class="bank-action-btn edit-btn edit-bank-question-btn" data-id="${esc(question.id)}" title="Editar pregunta">
                   <i class="bi bi-pencil"></i>
                 </button>
-                <button type="button" class="bank-action-btn delete-btn delete-bank-question-btn" data-id="${question.id}" title="Eliminar pregunta">
+                <button type="button" class="bank-action-btn delete-btn delete-bank-question-btn" data-id="${esc(question.id)}" title="Eliminar pregunta">
                   <i class="bi bi-trash"></i>
                 </button>
               </div>
@@ -792,7 +798,7 @@ document.addEventListener("DOMContentLoaded", () => {
         questionBankContainer.innerHTML = `
           <div class="alert alert-danger">
             <i class="bi bi-exclamation-triangle-fill me-2"></i>
-            Error al cargar las preguntas del banco: ${error.message}
+            Error al cargar las preguntas del banco: ${esc(error.message)}
             <div class="mt-2">
               <button type="button" class="btn btn-sm btn-outline-danger" onclick="updateQuestionBank()">
                 <i class="bi bi-arrow-clockwise me-1"></i> Reintentar
@@ -902,39 +908,31 @@ document.addEventListener("DOMContentLoaded", () => {
     questionCard.dataset.id = question.id
 
     // Construir el HTML de la pregunta
+    const qid = esc(question.id)
     questionCard.innerHTML = `
       <div class="card-header d-flex justify-content-between align-items-center">
           <div>
-              <span class="badge bg-info">${question.question_type_display}</span>
+              <span class="badge bg-info">${esc(question.question_type_display)}</span>
               ${question.is_required ? '<span class="badge bg-danger ms-1">Obligatorio</span>' : ""}
               ${question.allow_attachments ? '<span class="badge bg-info ms-1 attachment-allowed">Permite adjuntos</span>' : ""}
               ${question.in_question_bank ? '<span class="badge bg-success ms-1">En banco</span>' : ""}
           </div>
           <div class="btn-group">
-              <button type="button" class="btn btn-sm btn-outline-success save-to-bank-btn custom-tooltip" data-id="${question.id}" data-tooltip="Guardar en banco" ${question.in_question_bank ? "disabled" : ""}>
+              <button type="button" class="btn btn-sm btn-outline-success save-to-bank-btn custom-tooltip" data-id="${qid}" data-tooltip="Guardar en banco" ${question.in_question_bank ? "disabled" : ""}>
                   <i class="bi bi-archive"></i>
               </button>
-              <button type="button" class="btn btn-sm btn-outline-primary edit-question-btn custom-tooltip" data-id="${question.id}" data-tooltip="Editar pregunta">
+              <button type="button" class="btn btn-sm btn-outline-primary edit-question-btn custom-tooltip" data-id="${qid}" data-tooltip="Editar pregunta">
                   <i class="bi bi-pencil"></i>
               </button>
-              <button type="button" class="btn btn-sm btn-outline-danger delete-question-btn custom-tooltip" data-id="${question.id}" data-tooltip="Eliminar pregunta">
+              <button type="button" class="btn btn-sm btn-outline-danger delete-question-btn custom-tooltip" data-id="${qid}" data-tooltip="Eliminar pregunta">
                   <i class="bi bi-trash"></i>
               </button>
           </div>
       </div>
       <div class="card-body">
-          <h5 class="card-title">${question.text}</h5>
-          ${question.help_text ? `<p class="text-muted small">${question.help_text}</p>` : ""}
-          
-          ${
-            question.image
-              ? `
-          <div class="mt-2 mb-3">
-              <img src="${question.image}" alt="Imagen de la pregunta" class="img-fluid rounded" style="max-height: 200px;">
-          </div>
-          `
-              : ""
-          }
+          <h5 class="card-title">${esc(question.text)}</h5>
+          ${question.help_text ? `<p class="text-muted small">${esc(question.help_text)}</p>` : ""}
+          ${question.image ? `<div class="mt-2 mb-3"><img src="${esc(question.image)}" alt="Imagen de la pregunta" class="img-fluid rounded" style="max-height: 200px;"></div>` : ""}
       </div>
     `
 

--- a/checklist/static/js/script-for-form.js
+++ b/checklist/static/js/script-for-form.js
@@ -71,25 +71,41 @@ document.addEventListener("DOMContentLoaded", () => {
   
       urlInput.addEventListener("change", function () {
         if (this.value) {
-          const url = this.value.toLowerCase()
+          const rawUrl = this.value
+          const url = rawUrl.toLowerCase()
           previewContainer.classList.remove("d-none")
-  
+          previewContent.replaceChildren()  // clear previous preview safely
+
           if (url.endsWith(".jpg") || url.endsWith(".jpeg") || url.endsWith(".png") || url.endsWith(".gif")) {
-            previewContent.innerHTML = `<img src="${this.value}" class="img-fluid" alt="Vista previa">`
+            const img = document.createElement("img")
+            img.src = rawUrl          // browser sanitizes attribute assignment
+            img.className = "img-fluid"
+            img.alt = "Vista previa"
+            previewContent.appendChild(img)
           } else if (url.endsWith(".mp4") || url.endsWith(".webm") || url.endsWith(".ogg")) {
-            previewContent.innerHTML = `
-              <video controls class="img-fluid">
-                <source src="${this.value}" type="video/mp4">
-                Tu navegador no soporta la reproducción de videos.
-              </video>
-            `
+            const video = document.createElement("video")
+            video.controls = true
+            video.className = "img-fluid"
+            const source = document.createElement("source")
+            source.src = rawUrl
+            source.type = "video/mp4"
+            video.appendChild(source)
+            previewContent.appendChild(video)
           } else {
-            previewContent.innerHTML = `
-              <div class="p-3">
-                <p class="mb-2">URL proporcionada:</p>
-                <a href="${this.value}" target="_blank" class="d-block text-truncate">${this.value}</a>
-              </div>
-            `
+            const wrapper = document.createElement("div")
+            wrapper.className = "p-3"
+            const label = document.createElement("p")
+            label.className = "mb-2"
+            label.textContent = "URL proporcionada:"
+            const link = document.createElement("a")
+            link.href = rawUrl
+            link.target = "_blank"
+            link.rel = "noopener noreferrer"
+            link.className = "d-block text-truncate"
+            link.textContent = rawUrl   // textContent escapes — no XSS
+            wrapper.appendChild(label)
+            wrapper.appendChild(link)
+            previewContent.appendChild(wrapper)
           }
         }
       })

--- a/checklist/static/js/script-for-form.js
+++ b/checklist/static/js/script-for-form.js
@@ -54,7 +54,10 @@ document.addEventListener("DOMContentLoaded", () => {
                 </video>
               `
             } else {
-              previewContent.innerHTML = `<p class="p-3">Archivo seleccionado: ${file.name}</p>`
+              const p = document.createElement("p")
+              p.className = "p-3"
+              p.textContent = `Archivo seleccionado: ${file.name}`
+              previewContent.replaceChildren(p)
             }
           }
   

--- a/checklist/templates/base.html
+++ b/checklist/templates/base.html
@@ -142,6 +142,7 @@
  {% block styles %}{% endblock %}
  <!-- Extra head block for page-specific meta/links -->
  {% block extra_head %}{% endblock %}
+ <script>window.APP_DEBUG = {% if debug %}true{% else %}false{% endif %};</script>
 </head>
 <body class="d-flex flex-column min-vh-100">
  <!-- Debug info -->

--- a/checklist/templates/forms_google/edit_form.html
+++ b/checklist/templates/forms_google/edit_form.html
@@ -324,7 +324,7 @@
       {% if bank_questions %}
         <div id="questionBank" class="bank-questions-list">
           {% for question in bank_questions %}
-            <div class="bank-question-item" data-id="{{ question.id }}" data-type="{{ question.question_type }}" data-text="{{ question.text|slugify }}" data-hash="{{ question.hash|default:'' }}">
+            <div class="bank-question-item" data-id="{{ question.id }}" data-type="{{ question.question_type }}" data-text="{{ question.text|slugify }}">
               <span class="bank-question-type">{{ question.get_question_type_display }}</span>
               <div class="bank-question-text">{{ question.text }}</div>
               <div class="bank-question-meta">

--- a/checklist/templates/forms_google/question_bank.html
+++ b/checklist/templates/forms_google/question_bank.html
@@ -787,7 +787,7 @@
     <div id="questionBank" class="question-list">
       {% if bank_questions %}
         {% for question in bank_questions %}
-          <div class="question-item" data-id="{{ question.id }}" data-type="{{ question.question_type }}" data-text="{{ question.text|slugify }}" data-hash="{{ question.hash|default:'' }}">
+          <div class="question-item" data-id="{{ question.id }}" data-type="{{ question.question_type }}" data-text="{{ question.text|slugify }}">
             <div class="question-header">
               <div class="question-type">{{ question.get_question_type_display }}</div>
               <div class="question-date">{{ question.created_at|date:"d/m/Y" }}</div>

--- a/checklist/templates/forms_google/share_form.html
+++ b/checklist/templates/forms_google/share_form.html
@@ -74,7 +74,7 @@
               <div class="fs-user-permission">
                 <form method="post" action="{% url 'gform_add_permission' form_id=form.id %}" class="d-inline">
                   {% csrf_token %}
-                  <input type="hidden" name="user_email" value="{{ permission.user.email }}">
+                  <input type="hidden" name="permission_id" value="{{ permission.id }}">
                   <select name="permission_type" class="fs-permission-select" onchange="this.form.submit()">
                     <option value="viewer" {% if permission.permission_type == 'viewer' %}selected{% endif %}>{% trans_tag "Viewer" %}</option>
                     <option value="responder" {% if permission.permission_type == 'responder' %}selected{% endif %}>{% trans_tag "Responder" %}</option>

--- a/checklist/views.py
+++ b/checklist/views.py
@@ -6,6 +6,9 @@ from django.db import transaction, models
 from django.contrib import messages
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.core.validators import validate_email
+from django.core.exceptions import ValidationError
+from urllib.parse import urlparse
 from datetime import timedelta, date
 from django.contrib.auth import login, logout
 from django.contrib.auth.forms import AuthenticationForm
@@ -14,10 +17,13 @@ from django.template.loader import render_to_string
 from django_ratelimit.decorators import ratelimit
 import json
 import hashlib
+import logging
 import os
 import uuid
 from django.contrib.auth.models import User
 from django.urls import reverse
+
+logger = logging.getLogger(__name__)
 from .translation import translate
 from .models import (
     TodoList, Task, GForm, GQuestion, GOption, GResponse, GAnswer, GSelectedOption,
@@ -117,8 +123,9 @@ def todo_list_stats(request, list_id):
         })
     except TodoList.DoesNotExist:
         return JsonResponse({'error': _t(request, 'List not found')}, status=404)
-    except Exception as e:
-        return JsonResponse({'error': str(e)}, status=500)
+    except Exception:
+        logger.exception("todo_list_stats failed for list %s", list_id)
+        return JsonResponse({'error': _t(request, 'An error occurred')}, status=500)
 
 def _send_verification_email(request, user, ev):
     """Send branded HTML verification email. Silently logs on SMTP failure."""
@@ -421,22 +428,29 @@ def update_task_status(request, task_id):
             'status': task.status
         })
     
-    except Exception as e:
-        return JsonResponse({'error': str(e)}, status=400)
+    except Exception:
+        logger.exception("update_task_status failed for task %s", task_id)
+        return JsonResponse({'error': _t(request, 'An error occurred')}, status=400)
+
+_VALID_TASK_STATUSES = {'todo', 'progress', 'done'}
 
 @login_required
 @require_POST
 def update_tasks_order(request, list_id):
     """API para actualizar el orden de las tareas"""
     todo_list = get_object_or_404(TodoList, id=list_id)
-    
+
     # Verificar que el usuario sea el propietario
     if todo_list.user != request.user:
         return JsonResponse({'error': _t(request, "You don't have permission to modify this list")}, status=403)
-    
+
     try:
         data = json.loads(request.body)
-        
+
+        for status in data:
+            if status not in _VALID_TASK_STATUSES:
+                return JsonResponse({'error': _t(request, 'Invalid status')}, status=400)
+
         with transaction.atomic():
             for status, tasks in data.items():
                 for i, task_id in enumerate(tasks):
@@ -444,11 +458,12 @@ def update_tasks_order(request, list_id):
                         status=status,
                         position=i
                     )
-        
+
         return JsonResponse({'success': True})
-    
-    except Exception as e:
-        return JsonResponse({'error': str(e)}, status=400)
+
+    except Exception:
+        logger.exception("update_tasks_order failed for list %s", list_id)
+        return JsonResponse({'error': _t(request, 'An error occurred')}, status=400)
 
 # Vistas para Google Forms
 # Modificar la vista gform_list para pasar los permisos directamente al contexto
@@ -801,29 +816,25 @@ def gform_delete_question(request, question_id):
         
         messages.success(request, _t(request, "Question deleted from form successfully"))
         return redirect('gform_edit', form_id=form_id)
-    except Exception as e:
-        import traceback
-        error_traceback = traceback.format_exc()
-        print(f"Error al eliminar pregunta: {str(e)}\n{error_traceback}")
-        
+    except Exception:
+        logger.exception("gform_delete_question failed for question %s", question_id)
+
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
-            return JsonResponse({'success': False, 'error': str(e)})
-        
-        # Si no podemos obtener el ID del formulario de la pregunta (porque no existe),
-        # intentamos obtenerlo de la URL de referencia
+            return JsonResponse({'success': False, 'error': _t(request, 'Error deleting the question')})
+
+        # Try to redirect back to the form editor via Referer header
         try:
-            referer = request.META.get('HTTP_REFERER', '')
             import re
+            referer = request.META.get('HTTP_REFERER', '')
             form_id_match = re.search(r'/forms/(\d+)/edit/', referer)
             if form_id_match:
                 form_id = form_id_match.group(1)
-                messages.error(request, f"{_t(request, 'Error deleting the question')}: {str(e)}")
+                messages.error(request, _t(request, 'Error deleting the question'))
                 return redirect('gform_edit', form_id=form_id)
-        except:
+        except Exception:
             pass
-        
-        # Si todo falla, redirigir a la lista de formularios
-        messages.error(request, f"{_t(request, 'Error deleting the question')}: {str(e)}")
+
+        messages.error(request, _t(request, 'Error deleting the question'))
         return redirect('gform_list')
 
 @login_required
@@ -985,8 +996,9 @@ def gform_update_question_order(request, form_id):
                 GQuestion.objects.filter(id=question_id, form=gform).update(position=i)
         
         return JsonResponse({'success': True})
-    except Exception as e:
-        return JsonResponse({'success': False, 'error': str(e)}, status=400)
+    except Exception:
+        logger.exception("gform_update_question_order failed for form %s", form_id)
+        return JsonResponse({'success': False, 'error': _t(request, 'An error occurred')}, status=400)
 
 @login_required
 @require_POST
@@ -1022,8 +1034,9 @@ def gform_update_option_order(request, question_id):
                         pass
         
         return JsonResponse({'success': True})
-    except Exception as e:
-        return JsonResponse({'success': False, 'error': str(e)}, status=400)
+    except Exception:
+        logger.exception("gform_update_option_order failed for question %s", question_id)
+        return JsonResponse({'success': False, 'error': _t(request, 'An error occurred')}, status=400)
 
 @login_required
 def gform_toggle_publish(request, form_id):
@@ -1042,6 +1055,7 @@ def gform_toggle_publish(request, form_id):
     
     return redirect('gform_edit', form_id=gform.id)
 
+@ratelimit(key='ip', rate='20/5m', method='POST', block=True)
 def gform_view(request, form_id):
     """Vista para ver y responder a un formulario"""
     gform = get_object_or_404(GForm, id=form_id)
@@ -1064,43 +1078,54 @@ def gform_view(request, form_id):
         if not gform.is_published and not gform.can_respond(request.user):
             return HttpResponseForbidden(_t(request, "This form is not accepting responses"))
         
+        # Validate and sanitize respondent email (PT7)
+        raw_email = request.POST.get('email', '').strip() or None
+        if raw_email:
+            try:
+                validate_email(raw_email)
+                respondent_email = raw_email
+            except ValidationError:
+                respondent_email = None
+        else:
+            respondent_email = None
+
         # Crear una nueva respuesta
         response = GResponse.objects.create(
             form=gform,
             respondent=request.user if request.user.is_authenticated else None,
-            respondent_email=request.POST.get('email', None)
+            respondent_email=respondent_email,
         )
-        
+
         # Procesar cada pregunta
         for question in questions:
             field_name = f'question_{question.id}'
             file_field_name = f'file_{question.id}'
             url_field_name = f'url_{question.id}'
-            
+
             if field_name in request.POST or file_field_name in request.FILES or url_field_name in request.POST:
                 answer = GAnswer.objects.create(
                     response=response,
                     question=question
                 )
-                
+
                 if field_name in request.POST:
                     if question.question_type in ['short_text', 'paragraph', 'date', 'time', 'linear_scale']:
                         answer.text_answer = request.POST.get(field_name)
                         answer.save()
-                    
+
                     elif question.question_type in ['multiple_choice', 'dropdown']:
                         option_id = request.POST.get(field_name)
                         if option_id:
                             option = get_object_or_404(GOption, id=option_id)
                             GSelectedOption.objects.create(answer=answer, option=option)
-                    
+
                     elif question.question_type == 'checkbox':
                         # Para checkbox, value puede ser una lista
                         option_ids = request.POST.getlist(field_name)
                         for option_id in option_ids:
                             option = get_object_or_404(GOption, id=option_id)
                             GSelectedOption.objects.create(answer=answer, option=option)
-                
+
                 # Procesar archivos adjuntos solo si la pregunta permite adjuntos
                 if question.allow_attachments:
                     if file_field_name in request.FILES:
@@ -1110,15 +1135,18 @@ def gform_view(request, form_id):
                         elif file.content_type.startswith('video/'):
                             answer.video = file
                         answer.save()
-                    
-                    # Procesar URL
-                    if url_field_name in request.POST and request.POST.get(url_field_name):
-                        answer.file_url = request.POST.get(url_field_name)
-                        answer.save()
-        
+
+                    # Procesar URL — only accept http/https schemes (PT2)
+                    raw_url = request.POST.get(url_field_name, '').strip()
+                    if raw_url:
+                        parsed = urlparse(raw_url)
+                        if parsed.scheme in ('http', 'https'):
+                            answer.file_url = raw_url
+                            answer.save()
+
         messages.success(request, _t(request, "Thank you for your response!"))
         return redirect('gform_thank_you', form_id=gform.id)
-    
+
     return render(request, 'forms_google/view_form.html', {
         'gform': gform,
         'questions': questions,
@@ -1126,6 +1154,7 @@ def gform_view(request, form_id):
         'can_edit': gform.can_edit(request.user) if request.user.is_authenticated else False,
     })
 
+@ratelimit(key='ip', rate='20/5m', method='POST', block=True)
 def gform_respond(request, form_id):
     """Vista exclusiva para responder a un formulario sin opciones de edición"""
     gform = get_object_or_404(GForm, id=form_id)
@@ -1151,44 +1180,55 @@ def gform_respond(request, form_id):
     
     if request.method == 'POST':
         # Procesar la respuesta al formulario
-        
+
+        # Validate and sanitize respondent email (PT7)
+        raw_email = request.POST.get('email', '').strip() or None
+        if raw_email:
+            try:
+                validate_email(raw_email)
+                respondent_email = raw_email
+            except ValidationError:
+                respondent_email = None
+        else:
+            respondent_email = None
+
         # Crear una nueva respuesta
         response = GResponse.objects.create(
             form=gform,
             respondent=request.user if request.user.is_authenticated else None,
-            respondent_email=request.POST.get('email', None)
+            respondent_email=respondent_email,
         )
-        
+
         # Procesar cada pregunta
         for question in questions:
             field_name = f'question_{question.id}'
             file_field_name = f'file_{question.id}'
             url_field_name = f'url_{question.id}'
-            
+
             if field_name in request.POST or file_field_name in request.FILES or url_field_name in request.POST:
                 answer = GAnswer.objects.create(
                     response=response,
                     question=question
                 )
-                
+
                 if field_name in request.POST:
                     if question.question_type in ['short_text', 'paragraph', 'date', 'time', 'linear_scale']:
                         answer.text_answer = request.POST.get(field_name)
                         answer.save()
-                    
+
                     elif question.question_type in ['multiple_choice', 'dropdown']:
                         option_id = request.POST.get(field_name)
                         if option_id:
                             option = get_object_or_404(GOption, id=option_id)
                             GSelectedOption.objects.create(answer=answer, option=option)
-                    
+
                     elif question.question_type == 'checkbox':
                         # Para checkbox, value puede ser una lista
                         option_ids = request.POST.getlist(field_name)
                         for option_id in option_ids:
                             option = get_object_or_404(GOption, id=option_id)
                             GSelectedOption.objects.create(answer=answer, option=option)
-                
+
                 # Procesar archivos adjuntos solo si la pregunta permite adjuntos
                 if question.allow_attachments:
                     if file_field_name in request.FILES:
@@ -1198,15 +1238,18 @@ def gform_respond(request, form_id):
                         elif file.content_type.startswith('video/'):
                             answer.video = file
                         answer.save()
-                    
-                    # Procesar URL
-                    if url_field_name in request.POST and request.POST.get(url_field_name):
-                        answer.file_url = request.POST.get(url_field_name)
-                        answer.save()
-        
+
+                    # Procesar URL — only accept http/https schemes (PT2)
+                    raw_url = request.POST.get(url_field_name, '').strip()
+                    if raw_url:
+                        parsed = urlparse(raw_url)
+                        if parsed.scheme in ('http', 'https'):
+                            answer.file_url = raw_url
+                            answer.save()
+
         messages.success(request, _t(request, "Thank you for your response!"))
         return redirect('gform_thank_you', form_id=gform.id)
-    
+
     return render(request, 'forms_google/respond_form.html', {
         'gform': gform,
         'questions': questions
@@ -1560,14 +1603,9 @@ def gform_save_question_to_bank(request, question_id):
             'message': message,
             'bank_question_id': str(bank_question.id)
         })
-    except Exception as e:
-        import traceback
-        error_traceback = traceback.format_exc()
-        print(f"Error al guardar pregunta en banco: {str(e)}\n{error_traceback}")
-        return JsonResponse({
-            'success': False,
-            'error': str(e)
-        })
+    except Exception:
+        logger.exception("gform_save_question_to_bank failed for question %s", question_id)
+        return JsonResponse({'success': False, 'error': _t(request, 'An error occurred')})
 
 @login_required
 def gform_question_bank(request):
@@ -1607,22 +1645,15 @@ def gform_question_bank_json(request):
                 'is_required': question.is_required,
                 'allow_attachments': question.allow_attachments,
                 'created_at': question.created_at.isoformat() if question.created_at else None,
-                'hash': question.question_hash[:8] if question.question_hash else None  # Solo para depuración
             })
         
         return JsonResponse({
             'success': True,
             'bank_questions': questions_data
         })
-    except Exception as e:
-        import traceback
-        error_traceback = traceback.format_exc()
-        print(f"Error en gform_question_bank_json: {str(e)}\n{error_traceback}")
-        return JsonResponse({
-            'success': False,
-            'error': str(e),
-            'traceback': error_traceback
-        }, status=500)
+    except Exception:
+        logger.exception("gform_question_bank_json failed")
+        return JsonResponse({'success': False, 'error': _t(request, 'An error occurred')}, status=500)
 
 @login_required
 def gform_question_bank_detail(request, question_id):
@@ -1702,11 +1733,9 @@ def gform_question_bank_edit(request, question_id):
             'success': True,
             'message': 'Question updated successfully'
         })
-    except Exception as e:
-        return JsonResponse({
-            'success': False,
-            'error': str(e)
-        })
+    except Exception:
+        logger.exception("gform_question_bank_edit failed for question %s", question_id)
+        return JsonResponse({'success': False, 'error': _t(request, 'An error occurred')})
 
 @login_required
 @require_POST
@@ -1733,11 +1762,9 @@ def gform_question_bank_delete(request, question_id):
             'success': True,
             'message': 'Question deleted from bank successfully'
         })
-    except Exception as e:
-        return JsonResponse({
-            'success': False,
-            'error': str(e)
-        })
+    except Exception:
+        logger.exception("gform_question_bank_delete failed for question %s", question_id)
+        return JsonResponse({'success': False, 'error': _t(request, 'An error occurred')})
 
 # Modificar la función gform_add_from_bank para usar el nuevo sistema de hash
 @login_required
@@ -1819,14 +1846,9 @@ def gform_add_from_bank(request, form_id, question_id):
             'message': 'Pregunta añadida correctamente al formulario',
             'question': question_data
         })
-    except Exception as e:
-        import traceback
-        error_traceback = traceback.format_exc()
-        print(f"Error en gform_add_from_bank: {str(e)}\n{error_traceback}")
-        return JsonResponse({
-            'success': False,
-            'error': str(e)
-        })
+    except Exception:
+        logger.exception("gform_add_from_bank failed for form %s question %s", form_id, question_id)
+        return JsonResponse({'success': False, 'error': _t(request, 'An error occurred')})
 
 # Añadir una nueva vista para obtener las preguntas en formato JSON
 @login_required
@@ -1922,15 +1944,9 @@ def gform_clean_question_bank(request):
             'duplicates_removed': delete_count,
             'questions_kept': kept_count
         })
-    except Exception as e:
-        import traceback
-        error_traceback = traceback.format_exc()
-        print(f"Error en gform_clean_question_bank: {str(e)}\n{error_traceback}")
-        return JsonResponse({
-            'success': False,
-            'error': str(e),
-            'traceback': error_traceback
-        }, status=500)
+    except Exception:
+        logger.exception("gform_clean_question_bank failed")
+        return JsonResponse({'success': False, 'error': _t(request, 'An error occurred')}, status=500)
 
 # Nuevas vistas para gestionar permisos de formularios
 @login_required

--- a/checklist/views.py
+++ b/checklist/views.py
@@ -1522,7 +1522,9 @@ def export_response_to_excel(request, response_id):
     http_response = HttpResponse(
         content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     )
-    http_response['Content-Disposition'] = f'attachment; filename=respuesta_{response_obj.id}_{gform.title.replace(" ", "_")}.xlsx'
+    from urllib.parse import quote as _url_quote
+    safe_title = _url_quote(gform.title, safe='')
+    http_response['Content-Disposition'] = f'attachment; filename="respuesta_{response_obj.id}_{safe_title}.xlsx"'
     
     # Guardar el libro de Excel en la respuesta HTTP
     wb.save(http_response)

--- a/checklist/views.py
+++ b/checklist/views.py
@@ -5,11 +5,13 @@ from django.views.decorators.http import require_POST
 from django.db import transaction, models
 from django.contrib import messages
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from datetime import timedelta, date
 from django.contrib.auth import login, logout
 from django.contrib.auth.forms import AuthenticationForm
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
+from django_ratelimit.decorators import ratelimit
 import json
 import hashlib
 import os
@@ -144,6 +146,7 @@ def _send_verification_email(request, user, ev):
         logging.getLogger(__name__).error('Error sending verification email to %s: %s', user.email, exc)
 
 
+@ratelimit(key='ip', rate='5/h', method='POST', block=True)
 def register_view(request):
     if request.method == 'POST':
         form = UserRegistrationForm(request.POST)
@@ -182,6 +185,7 @@ def verify_email(request, token):
 
 
 @login_required
+@ratelimit(key='user', rate='3/10m', method='POST', block=True)
 def verify_email_resend(request):
     """Invalidate old tokens and send a fresh verification email."""
     if request.method == 'POST':
@@ -193,18 +197,19 @@ def verify_email_resend(request):
         messages.success(request, _t(request, 'Verification email sent'))
     return redirect('verify_email_sent')
 
+@ratelimit(key='ip', rate='10/5m', method='POST', block=True)
 def login_view(request):
     if request.method == 'POST':
         form = AuthenticationForm(data=request.POST)
         if form.is_valid():
             login(request, form.get_user())
-            # Redirigir a la URL guardada en la sesión si existe
-            next_url = request.session.get('next', 'dashboard')
-            if 'next' in request.session:
-                del request.session['next']
-            return redirect(next_url)
+            next_url = request.session.pop('next', None)
+            if next_url and url_has_allowed_host_and_scheme(
+                next_url, allowed_hosts={request.get_host()}
+            ):
+                return redirect(next_url)
+            return redirect('dashboard')
     else:
-        # Guardar la URL de redirección si viene en la solicitud
         if 'next' in request.GET:
             request.session['next'] = request.GET.get('next')
         form = AuthenticationForm()
@@ -1931,49 +1936,54 @@ def gform_clean_question_bank(request):
 @login_required
 @require_POST
 def gform_add_permission(request, form_id):
-    """Vista para añadir un permiso a un usuario para un formulario"""
+    """Vista para añadir o actualizar un permiso en un formulario"""
     gform = get_object_or_404(GForm, id=form_id)
-    
-    # Verificar que el usuario sea el propietario
+
     if gform.user != request.user:
         return HttpResponseForbidden(_t(request, "Only the owner can manage permissions"))
-    
+
+    # Update path: existing permission identified by ID (no email in DOM)
+    permission_id = request.POST.get('permission_id')
+    if permission_id:
+        permission = get_object_or_404(FormPermission, id=permission_id, form=gform)
+        permission_type = request.POST.get('permission_type', '')
+        valid_types = {c[0] for c in FormPermission.PERMISSION_CHOICES}
+        if permission_type not in valid_types:
+            messages.error(request, _t(request, 'Invalid permission type'))
+            return redirect('gform_share_form', form_id=gform.id)
+        permission.permission_type = permission_type
+        permission.save(update_fields=['permission_type'])
+        messages.success(request, f"{_t(request, 'Permission updated for')} {permission.user.username}")
+        return redirect('gform_share_form', form_id=gform.id)
+
+    # Create path: new permission by email
     form = FormPermissionForm(request.POST)
     if form.is_valid():
-        # Obtener el usuario por correo electrónico
         email = form.cleaned_data['user_email']
         try:
             user = User.objects.get(email=email)
-            
-            # Verificar que no se esté intentando dar permisos al propietario
+
             if user == gform.user:
                 messages.error(request, _t(request, "You cannot add permissions to the form owner"))
                 return redirect('gform_share_form', form_id=gform.id)
-            
-            # Verificar que el permiso sea de editor solo si el usuario tiene cuenta
+
             permission_type = form.cleaned_data['permission_type']
-            if permission_type == 'editor' and not user.is_authenticated:
-                messages.error(request, _t(request, "Only registered users can have editor permissions"))
-                return redirect('gform_share_form', form_id=gform.id)
-            
-            # Crear o actualizar el permiso
-            permission, created = FormPermission.objects.update_or_create(
+            _, created = FormPermission.objects.update_or_create(
                 form=gform,
                 user=user,
                 defaults={'permission_type': permission_type}
             )
-            
+
             if created:
                 messages.success(request, f"{_t(request, 'Permission added for')} {user.username}")
             else:
                 messages.success(request, f"{_t(request, 'Permission updated for')} {user.username}")
-            
+
         except User.DoesNotExist:
             messages.error(request, f"{_t(request, 'No user found with email')} {email}")
-        
+
         return redirect('gform_share_form', form_id=gform.id)
-    
-    # Si hay errores en el formulario
+
     for field, errors in form.errors.items():
         for error in errors:
             messages.error(request, f"{_t(request, 'Error in')} {field}: {error}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,13 +10,14 @@ django-crispy-forms==2.3
 django-widget-tweaks==1.5.0
 environs==14.1.1
 et_xmlfile==2.0.0
+django-ratelimit==4.1.0  # imports as django_ratelimit
 gunicorn==23.0.0
 idna==3.10
 marshmallow==3.26.1
 numpy==2.4.2
 openpyxl==3.1.5
 packaging==24.2
-pillow==12.1.1
+pillow==12.2.0
 psycopg2-binary==2.9.11
 python-dotenv==1.1.0
 pytz==2025.1
@@ -26,5 +27,5 @@ rjsmin==1.2.2
 sqlparse==0.5.3
 typing_extensions==4.12.2
 tzdata==2025.1
-urllib3==2.3.0
+urllib3==2.7.0
 whitenoise==6.9.0


### PR DESCRIPTION
# Security Hardening — Rate Limiting, Headers, XSS, Dependency Upgrades

**Branch:** `feat/security-hardening`  
**Base:** `main`  
**Date:** 2026-05-15  

---

## Summary

Comprehensive security audit and hardening of DragTask across three passes:

1. **Initial hardening** — production settings, CSP headers, rate limiting, file upload validators, open redirect fix, sensitive data removed from DOM, console logs gated.
2. **Post-review fixes** — stored XSS in JavaScript `innerHTML` blocks, video file validators, `Content-Disposition` header injection.
3. **Penetration testing fixes** — Python tracebacks leaked to clients, stored XSS via `javascript:` URL scheme, raw exception messages in API responses, form submission spam, arbitrary task status values, hash exposure in JSON API, unvalidated `respondent_email`.

No migrations required. All changes are additive (new middleware, decorators, validators).

---

## Commits

| Hash | Description |
|------|-------------|
| `7690171` | feat(security): harden app — rate limiting, headers, XSS, dep upgrades |
| `2d317e9` | security(pentest): fix PT1–PT7 from penetration testing audit |
| `6fa651f` | security(post-review): fix FR1–FR5 from code review follow-up |

---

## Pass 1 — Initial Hardening

### Settings (`app_checklist/settings.py`)

- `ALLOWED_HOSTS = ["*"]` replaced — dev uses `localhost/127.0.0.1`, prod reads from `ALLOWED_HOSTS` env var
- Security headers applied in both environments: `SECURE_CONTENT_TYPE_NOSNIFF`, `X_FRAME_OPTIONS = 'DENY'`, `CSRF_COOKIE_HTTPONLY`, `SESSION_COOKIE_HTTPONLY`
- Production-only HTTPS gates: `SECURE_SSL_REDIRECT`, `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `SECURE_HSTS_SECONDS = 31536000`, `SECURE_HSTS_INCLUDE_SUBDOMAINS`, `SECURE_HSTS_PRELOAD`
- `MinimumLengthValidator` raised from 8 → 10 characters
- `django.security` logger added to capture `SuspiciousOperation`, CSRF failures, `DisallowedHost`, etc.

### Security Headers Middleware (`checklist/middleware.py`)

New `SecurityHeadersMiddleware` class added and registered after `SecurityMiddleware`:

| Header | Value |
|--------|-------|
| `Content-Security-Policy` | `default-src 'self'`; scripts/styles allow `cdn.jsdelivr.net` (Bootstrap CDN) |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `geolocation=(), camera=(), microphone=()` |

`CachedLanguageMiddleware` updated to validate the language parameter against `{'es', 'en'}` before storing in session/cache.

### Rate Limiting (`checklist/views.py`)

`django-ratelimit==4.1.0` added to `requirements.txt`. Applied to authentication-facing endpoints:

| View | Rate | Key |
|------|------|-----|
| `login_view` | 10 req / 5 min | IP |
| `register_view` | 5 req / hour | IP |
| `verify_email_resend` | 3 req / 10 min | user |

### Open Redirect Fix (`checklist/views.py`)

`login_view` redirect after login now validated with Django's `url_has_allowed_host_and_scheme`:

```python
next_url = request.session.pop('next', None)
if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts={request.get_host()}):
    return redirect(next_url)
return redirect('dashboard')
```

### File Upload Validators (`checklist/models.py`)

`validate_image_extension` and `validate_image_size` (5 MB cap) added and applied to all three `ImageField`s: `BankQuestion.image`, `GQuestion.image`, `GAnswer.image`.

### Dependency Upgrades (`requirements.txt`)

| Package | Before | After | CVEs fixed |
|---------|--------|-------|-----------|
| `Pillow` | 12.1.1 | 12.2.0 | CVE-2026-40192 (FITS DoS), CVE-2026-25990 (PSD OOB write) |
| `urllib3` | 2.3.0 | 2.7.0 | CVE-2025-50181 (redirect bypass/SSRF), CVE-2025-66418/66471 (decompression DoS) |

### Sensitive Data Removed from DOM

- `share_form.html` — `user_email` hidden field replaced with `permission_id`; `gform_add_permission` view updated to accept both update-by-ID and create-by-email paths
- `edit_form.html` + `question_bank.html` — `data-hash` attribute removed from all question container divs
- `base.html` — `window.APP_DEBUG` flag injected; all `console.log` calls in `question_bank.js`, `edit_form.js`, `demo-hero.js` gated behind it

---

## Pass 2 — Post-Review Fixes (FR1–FR5)

### FR1 — Stored XSS via `innerHTML` with user data (`edit_form.js`, `question_bank.js`)

`esc()` HTML-escape helper added to both files:

```js
function esc(s) {
  const d = document.createElement("div")
  d.textContent = String(s ?? "")
  return d.innerHTML
}
```

All user-controlled values (`question.text`, `question.help_text`, `question.question_type_display`, `question.image`, `question.id`) now wrapped with `esc()` in every `innerHTML` template literal. Without this, an editor-role user could save `<img src=x onerror=alert(document.cookie)>` as a question title and execute JS in every other editor's browser.

### FR2 — `file.name` via `innerHTML` (`script-for-form.js`)

File preview for non-image/video attachments replaced with safe DOM construction:

```js
const p = document.createElement("p")
p.className = "p-3"
p.textContent = `Archivo seleccionado: ${file.name}`
previewContent.replaceChildren(p)
```

### FR3 — `GAnswer.video` lacks validators (`checklist/models.py`)

`validate_video_extension` (mp4/webm/ogg/mov only) and `validate_video_size` (50 MB cap) added and applied to `GAnswer.video`. Previously the field accepted any file without checks and the view trusted the browser-supplied `content_type`.

### FR4 — `Content-Disposition` header injection (`checklist/views.py`)

Excel export response header now percent-encodes the form title, preventing HTTP header injection via newlines or quotes in user-controlled form names:

```python
from urllib.parse import quote as _url_quote
safe_title = _url_quote(gform.title, safe='')
http_response['Content-Disposition'] = f'attachment; filename="respuesta_{response_obj.id}_{safe_title}.xlsx"'
```

### FR5 — `error.message` via `innerHTML` (`question_bank.js`)

Error message in the fetch catch block wrapped with `esc()` to prevent XSS if the server returns user-controlled content in an error payload.

---

## Pass 3 — Penetration Testing Fixes (PT1–PT7)

### PT1 — Full Python traceback returned to clients (`checklist/views.py`)

Four views were returning `traceback` / `str(e)` directly in JSON responses, exposing server directory structure, module names, and DB schema. All four replaced with `logger.exception(...)` (server-side) + generic `"An error occurred"` response to client:

- `gform_question_bank_json`
- `gform_save_question_to_bank`
- `gform_add_from_bank`
- `gform_clean_question_bank`

### PT2 — Stored XSS via `javascript:` URL in `file_url` (`checklist/views.py`)

`GAnswer.file_url` was saved directly from POST with no scheme check. `response_detail.html` renders it in `<a href="{{ answer.file_url }}">` — Django auto-escaping does not catch `javascript:` since it contains no HTML-special characters. Both `gform_view` and `gform_respond` now validate the scheme before saving:

```python
parsed = urlparse(raw_url)
if parsed.scheme in ('http', 'https'):
    answer.file_url = raw_url
    answer.save()
```

### PT3 — `str(e)` leaks DB schema in 8 JSON endpoints (`checklist/views.py`)

ORM exception messages (e.g. `UNIQUE constraint failed: checklist_formpermission.form_id`) were returned verbatim. All 8 endpoints now return `_t(request, 'An error occurred')` and log the real exception server-side:

- `todo_list_stats`
- `update_task_status`
- `update_tasks_order`
- `gform_delete_question`
- `gform_update_question_order`
- `gform_update_option_order`
- `gform_question_bank_edit`
- `gform_question_bank_delete`

### PT4 — No rate limit on form submission (`checklist/views.py`)

Published forms could be flooded with unlimited responses. Both response views now rate-limited:

```python
@ratelimit(key='ip', rate='20/5m', method='POST', block=True)
def gform_view(request, form_id): ...

@ratelimit(key='ip', rate='20/5m', method='POST', block=True)
def gform_respond(request, form_id): ...
```

### PT5 — Arbitrary status values written to DB (`checklist/views.py`)

`update_tasks_order` iterated over user-supplied JSON keys as `status` values and passed them directly to `Task.objects.update()`. Django's `.update()` does not enforce `choices`. A whitelist check added before the loop:

```python
_VALID_TASK_STATUSES = {'todo', 'progress', 'done'}

for status in data:
    if status not in _VALID_TASK_STATUSES:
        return JsonResponse({'error': _t(request, 'Invalid status')}, status=400)
```

### PT6 — Question hash exposed in JSON API (`checklist/views.py`)

`gform_question_bank_json` was returning 8 characters of the SHA256 question hash labeled "Solo para depuración". Removed from the response entirely.

### PT7 — `respondent_email` stored without validation (`checklist/views.py`)

`email` POST field was stored directly without format checking in both `gform_view` and `gform_respond`. Now validated with Django's `EmailValidator`; silently discarded if invalid:

```python
from django.core.validators import validate_email
raw_email = request.POST.get('email', '').strip() or None
if raw_email:
    try:
        validate_email(raw_email)
        respondent_email = raw_email
    except ValidationError:
        respondent_email = None
```

---

## Files Changed

| File | Changes |
|------|---------|
| `requirements.txt` | Pillow 12.2.0, urllib3 2.7.0, django-ratelimit 4.1.0 |
| `app_checklist/settings.py` | ALLOWED_HOSTS, security headers, HSTS (prod), password policy, security logger |
| `checklist/middleware.py` | SecurityHeadersMiddleware (CSP + 3 headers), language whitelist |
| `checklist/models.py` | Image validators on 3 fields; video validators on GAnswer.video |
| `checklist/views.py` | Rate limits (5 views), open redirect fix, permission_id lookup, URL scheme validation, email validation, status whitelist, generic error messages (8 endpoints), traceback removal (4 endpoints), Content-Disposition encoding, hash removed from JSON |
| `checklist/static/js/edit_form.js` | `esc()` helper; all user values wrapped in innerHTML template literals |
| `checklist/static/js/question_bank.js` | `esc()` helper; all user values + error.message wrapped; data-hash attribute removed |
| `checklist/static/js/script-for-form.js` | URL preview via DOM API (no innerHTML); file.name via textContent |
| `checklist/static/js/demo-hero.js` | console.log gated behind APP_DEBUG |
| `checklist/templates/base.html` | APP_DEBUG flag injected |
| `checklist/templates/forms_google/share_form.html` | permission_id replaces user_email hidden field |
| `checklist/templates/forms_google/edit_form.html` | data-hash attribute removed |
| `checklist/templates/forms_google/question_bank.html` | data-hash attribute removed |

---

## Testing

- [x] `python manage.py check` — 0 issues
- [x] Dev server starts and UI renders correctly (Bootstrap CDN loads via CSP whitelist)
- [x] Response headers include `Content-Security-Policy`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`
- [x] Login form > 10 attempts in 5 min from same IP → 429
- [x] Register > 5 times from same IP in 1 hour → 429
- [x] Upload image > 5 MB → rejected with validation error
- [x] Language set to invalid value via GET param → defaults to `es`
- [x] `next` session key forged to external URL → redirects to dashboard
- [x] Question bank panel loads and displays questions correctly
- [x] Form submission with `javascript:alert(1)` as file URL → URL silently discarded
- [x] Form submission with invalid email → email silently discarded
- [x] Task drag-and-drop order update rejects unknown status values
- [x] Excel export downloads with percent-encoded filename
- [x] console.log absent in browser devtools when APP_DEBUG = false

---

## Out of Scope (follow-up PRs)

- `django-axes` for persistent login attempt tracking
- 2FA / TOTP support
- Argon2 password hasher migration
- UUID on `GResponse` to prevent response ID enumeration
- Full nonce-based CSP (requires template refactor to remove `unsafe-inline`)
